### PR TITLE
Use the correct pb definition for sls logs from go sdk

### DIFF
--- a/cn.zh-CN/API 参考/公共资源说明/数据编码方式.md
+++ b/cn.zh-CN/API 参考/公共资源说明/数据编码方式.md
@@ -3,15 +3,27 @@
 Protocol Buffer是 Google 开发的用于结构化数据交换格式，被广泛用于 Google 内部及外部很多服务。目前，日志服务也使用 Protocol Buffer 格式作为标准的日志写入格式。当用户需要写入日志时，需要把原始日志数据序列化成如下格式的 Protocol Buffer 数据流后才能通过 API 写入服务端：
 
 ```
+syntax = "proto2";
+package sls;
+
+import "gogo.proto";
+
+option (gogoproto.sizer_all) = true;
+option (gogoproto.marshaler_all) = true;
+option (gogoproto.unmarshaler_all) = true;
+
+message LogContent
+{
+    required string Key = 1;
+    required string Value = 2;
+}  
+
 message Log
 {
     required uint32 Time = 1;// UNIX Time Format
-    message Content
-    {
-        required string Key = 1;
-        required string Value = 2;
-    }  
-    repeated Content Contents = 2;
+    
+    repeated LogContent Contents= 2;
+
 }
 
 message LogTag
@@ -23,15 +35,27 @@ message LogTag
 message LogGroup
 {
     repeated Log Logs= 1;
-    optional string Reserved = 2; // reserved fields
+    optional string Category = 2;
     optional string Topic = 3;
     optional string Source = 4;
+    optional string MachineUUID = 5;
     repeated LogTag LogTags = 6;
+}
+
+message SlsLogPackage
+{
+    required bytes data = 1;  // the serialized data of LogGroup , may be compressed
+    optional int32 uncompress_size = 2;  
+}
+
+message SlsLogPackageList
+{
+    repeated SlsLogPackage packages = 1;
 }
 
 message LogGroupList
 {
-    repeated LogGroup logGroupList = 1;
+    repeated LogGroup LogGroups = 1;
 }
 ```
 

--- a/intl.en-US/API Reference/Common resources/Data encoding method.md
+++ b/intl.en-US/API Reference/Common resources/Data encoding method.md
@@ -3,15 +3,27 @@
 Protocol Buffer is a structured data interchange format developed by Google. It is widely used in many internal and external services of Google.  Currently, Log Service uses Protocol Buffer format as  the standard log writing format.  You must serialize the original log data into Protocol Buffer data streams before writing logs to Log Service by using APIs.
 
 ```
+syntax = "proto2";
+package sls;
+
+import "gogo.proto";
+
+option (gogoproto.sizer_all) = true;
+option (gogoproto.marshaler_all) = true;
+option (gogoproto.unmarshaler_all) = true;
+
+message LogContent
+{
+    required string Key = 1;
+    required string Value = 2;
+}  
+
 message Log
 {
     required uint32 Time = 1;// UNIX Time Format
-    message Content
-    {
-        required string Key = 1;
-        required string Value = 2;
-    }  
-    repeated Content Contents = 2;
+    
+    repeated LogContent Contents= 2;
+
 }
 
 message LogTag
@@ -23,15 +35,27 @@ message LogTag
 message LogGroup
 {
     repeated Log Logs= 1;
-    optional string Reserved = 2; // reserved fields
+    optional string Category = 2;
     optional string Topic = 3;
     optional string Source = 4;
+    optional string MachineUUID = 5;
     repeated LogTag LogTags = 6;
+}
+
+message SlsLogPackage
+{
+    required bytes data = 1;  // the serialized data of LogGroup , may be compressed
+    optional int32 uncompress_size = 2;  
+}
+
+message SlsLogPackageList
+{
+    repeated SlsLogPackage packages = 1;
 }
 
 message LogGroupList
 {
-    repeated LogGroup logGroupList = 1;
+    repeated LogGroup LogGroups = 1;
 }
 ```
 

--- a/intl.zh-CN/API 参考/公共资源说明/数据编码方式.md
+++ b/intl.zh-CN/API 参考/公共资源说明/数据编码方式.md
@@ -3,15 +3,27 @@
 Protocol Buffer是 Google 开发的用于结构化数据交换格式，被广泛用于 Google 内部及外部很多服务。目前，日志服务也使用 Protocol Buffer 格式作为标准的日志写入格式。当用户需要写入日志时，需要把原始日志数据序列化成如下格式的 Protocol Buffer 数据流后才能通过 API 写入服务端：
 
 ```
+syntax = "proto2";
+package sls;
+
+import "gogo.proto";
+
+option (gogoproto.sizer_all) = true;
+option (gogoproto.marshaler_all) = true;
+option (gogoproto.unmarshaler_all) = true;
+
+message LogContent
+{
+    required string Key = 1;
+    required string Value = 2;
+}  
+
 message Log
 {
     required uint32 Time = 1;// UNIX Time Format
-    message Content
-    {
-        required string Key = 1;
-        required string Value = 2;
-    }  
-    repeated Content Contents = 2;
+    
+    repeated LogContent Contents= 2;
+
 }
 
 message LogTag
@@ -23,15 +35,27 @@ message LogTag
 message LogGroup
 {
     repeated Log Logs= 1;
-    optional string Reserved = 2; // reserved fields
+    optional string Category = 2;
     optional string Topic = 3;
     optional string Source = 4;
+    optional string MachineUUID = 5;
     repeated LogTag LogTags = 6;
+}
+
+message SlsLogPackage
+{
+    required bytes data = 1;  // the serialized data of LogGroup , may be compressed
+    optional int32 uncompress_size = 2;  
+}
+
+message SlsLogPackageList
+{
+    repeated SlsLogPackage packages = 1;
 }
 
 message LogGroupList
 {
-    repeated LogGroup logGroupList = 1;
+    repeated LogGroup LogGroups = 1;
 }
 ```
 


### PR DESCRIPTION
官网文档中对SLS日志格式的定义有问题，可以使用go-sdk中的定义：

https://github.com/aliyun/aliyun-log-go-sdk/blob/master/log.proto